### PR TITLE
Update for Ved 1.11.0

### DIFF
--- a/info.lua
+++ b/info.lua
@@ -4,7 +4,7 @@ t.shortname = "Future"  -- The name that will be displayed on the button in the 
 t.longname = "Future"  -- This can be about twice as long
 t.author = "AllyTally"  -- Your name
 t.version = "1.0-alpha"  -- The current version of this plugin, can be anything you want
-t.minimumved = "1.10.0"  -- The minimum version of Ved this plugin is designed to work with. If unsure, just use the latest version.
+t.minimumved = "1.11.0"  -- The minimum version of Ved this plugin is designed to work with. If unsure, just use the latest version.
 t.description = [[
 Support for VVVVVV PRs which may or may not get merged in the future.
 ]]  -- The description that will be displayed in the plugins list. This uses the help/notepad system, so you can use text formatting here, and even images!

--- a/sourceedits.lua
+++ b/sourceedits.lua
@@ -120,15 +120,11 @@ end]],
 cons("Loading entity colors...")
 if contents then
 	future_entitycolors = contents:match("<EntityColours>(.*)</EntityColours>")
-	future_textboxcolors = contents:match("<TextboxColours>(.*)</TextboxColours>")
 	future_markers = contents:match("<Markers>(.*)</Markers>")
-	future_roomnames = contents:match("<SpecialRoomnames>(.*)</SpecialRoomnames>")
 	future_altstates = contents:match("<altstates>(.*)</altstates>")
 else
 	future_entitycolors = ""
-	future_textboxcolors = ""
 	future_markers = ""
-	future_roomnames = ""
 	future_altstates = ""
 end
 
@@ -141,9 +137,7 @@ end
 			find = [[cons("Saving room metadata...")]],
 			replace = [[
 savethis = savethis:gsub("%$ENTITYCOLORS%$", future_entitycolors or "")
-savethis = savethis:gsub("%$TEXTBOXCOLORS%$", future_textboxcolors or "")
 savethis = savethis:gsub("%$MARKERS%$", future_markers or "")
-savethis = savethis:gsub("%$ROOMNAMES%$", future_roomnames or "")
 savethis = savethis:gsub("%$ALTSTATES%$", future_altstates or "")
 cons("Saving room metadata...")]],
 			ignore_error = false,
@@ -151,10 +145,10 @@ cons("Saving room metadata...")]],
 			allowmultiple = false,
 		},
 		{
-			find = [[vvvvvvxmltemplate = love.filesystem.read("template.vvvvvv")]],
+			find = [[level_template = love.filesystem.read("template.vvvvvv") -- updated 1.11.0]],
 			replace = [[
-vvvvvvxmltemplate = love.filesystem.read("template.vvvvvv")
-vvvvvvxmltemplate = vvvvvvxmltemplate:gsub("</Data>", "    <EntityColours>$ENTITYCOLORS$</EntityColours>\n        <TextboxColours>$TEXTBOXCOLORS$</TextboxColours>\n        <Markers>$MARKERS$</Markers>\n        <SpecialRoomnames>$ROOMNAMES$</SpecialRoomnames>\n        <altstates>$ALTSTATES$</altstates>\n    </Data>")]],
+level_template = love.filesystem.read("template.vvvvvv")
+level_template = level_template:gsub("</Data>", "    <EntityColours>$ENTITYCOLORS$</EntityColours>\n        <Markers>$MARKERS$</Markers>\n        <altstates>$ALTSTATES$</altstates>\n    </Data>")]],
 			ignore_error = false,
 			luapattern = false,
 			allowmultiple = false,


### PR DESCRIPTION
Ved now reads and saves the `<TextboxColours>` and `<SpecialRoomnames>` itself. This means Future should no longer do the same thing - otherwise tags would get duplicated in level files. `vvvvvvxmltemplate` is now renamed on purpose to prevent this from happening without warning.

This also adds a little protection against including the Future plugin itself multiple times - the `-- updated 1.11.0` comment is removed, meaning it can only be found and replaced a single time.